### PR TITLE
Adds documentation curation, enables documentation on SPI

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - platform: ios
+      documentation_targets: [Boutique]

--- a/Sources/Boutique/Documentation.docc/Articles/Example.md
+++ b/Sources/Boutique/Documentation.docc/Articles/Example.md
@@ -1,0 +1,59 @@
+# Building a simple SwiftUI app with Boutique
+
+Build an offline-capable SwiftUI app with Boutique in just few steps.
+
+## Overview
+
+Persist `Codable` data models and drive your SwiftUI app with Boutique.
+
+### Define data models
+
+Define your model types as usual for a SwiftUI app. Conform to `Identifiable` to make it easier to unqiuely reference models:
+
+```swift
+struct RemoteImage: Codable, Equatable, Identifiable {
+  let url: URL
+  let dataRepresentation: Data
+
+  var id: String {
+    url.absoluteString
+  }
+}
+```
+
+### Create a data store for your type(s)
+
+Define a default store for a given data type. Add an extension on ``Store`` when the stored data type is your model and define the location on disk to persist the objects: 
+
+```swift
+extension Store where Item == RemoteImage {
+  static let imagesStore = Store<RemoteImage>(
+    storagePath: Store.documentsDirectory(appendingPath: "Images")
+  )
+}
+```
+
+### Drive the app's UI from your data store
+
+Finally, bind the store to drive your app's UI:
+
+```swift
+struct ContentView: View {
+  @Stored(in: .imagesStore) var images
+
+  var body: some View {
+    List(images, id: \.id) { image in
+      Image(uiImage: .init(data: image.dataRepresentation)!)
+    }
+  }
+}
+```
+
+If you want to perform sorting, filtering, or otherwise process the stored objects before binding them to your UI, add the store to a controller (`ObservedObject`) to do that and bind the UI to its published properties.
+
+## See Also
+
+This article is an abbreviated version of the content in the Boutique announcement blog post and its accompanying example app:
+
+ - [Model View Controller Store](https://build.ms/2022/06/22/model-view-controller-store)
+ - [MVCS: A Simple, Familiar, Yet Powerful Architecture for building SwiftUI Apps](https://github.com/mergesort/MVCS)

--- a/Sources/Boutique/Documentation.docc/Boutique.md
+++ b/Sources/Boutique/Documentation.docc/Boutique.md
@@ -1,0 +1,22 @@
+# ``Boutique``
+
+A batteries-included app persistence layer, called `Store`, that comes with everything you'll need out of the box. 
+
+## Overview
+
+Boutique's Store is a dual-layered memory and disk cache which lets you build apps that update in real time with full offline storage and an incredibly simple API in only a few lines of code. It fits really well with SwiftUI apps that need a single source of truth data model to drive the UI. 
+
+Boutique is powered under the hood by `Bodega`, an actor-based library for saving data and `Codable` objects to disk.
+
+For more details on the library motivation and design details, read [Model View Controller Store: Reinventing MVC for SwiftUI with Boutique](https://build.ms/2022/06/22/model-view-controller-store/).
+
+## Topics
+
+### Essentials
+
+- <doc:Example>
+
+### Data Storage
+
+- ``Store``
+- ``Stored``

--- a/Sources/Boutique/Documentation.docc/Extensions/Store.md
+++ b/Sources/Boutique/Documentation.docc/Extensions/Store.md
@@ -1,0 +1,39 @@
+# ``Boutique/Store``
+
+## Creating and using a store
+
+You define and initialize a store in just few lines. 
+
+Once you've configured a store for a certain data type you can use it in your controllers or views as:
+
+```swift
+@Stored(in: .imagesStore) var images
+```
+
+`images` above is then a collection of the stored type so you can loop over it, bind it, and filter is usual.
+
+For a more detailed code example refer to <doc:Example>.
+
+## Topics
+
+### Initialization
+
+ - ``init(storagePath:)``
+ - ``init(storagePath:cacheIdentifier:)``
+
+### Content
+
+ - ``items``
+
+### Updating the store
+
+ - ``add(_:invalidationStrategy:)-5y90k``
+ - ``add(_:invalidationStrategy:)-4mi2i``
+
+ - ``remove(_:)-5dwyv``
+ - ``remove(_:)-3nzlq``
+ - ``removeAll()``
+
+### Invalidation
+
+ - ``CacheInvalidationStrategy``

--- a/Sources/Boutique/Documentation.docc/Extensions/Stored.md
+++ b/Sources/Boutique/Documentation.docc/Extensions/Stored.md
@@ -1,0 +1,9 @@
+# ``Boutique/Stored``
+
+## Overview
+
+Once you've configured a `Store` for your data type, you can use `@Stored` to easily instantiate the store in your controller or view types like so:
+
+```swift
+@Stored(in: Store.imagesStore) var images
+```

--- a/Sources/Boutique/Store+Directories.swift
+++ b/Sources/Boutique/Store+Directories.swift
@@ -22,8 +22,7 @@ public extension Store {
         DiskStorage.temporaryDirectory(appendingPath: pathComponent)
     }
 
-    /// For apps that use the App Groups feature this function returns a URL that
-    /// appends a path to the app's group shared directory.
+    /// Returns a URL that appends a path to the app's group shared directory (for apps that use the App Groups feature). 
     ///
     /// - Parameters:
     ///   - identifier: The app's group identifier as declared in your app's App Groups Entitlement.

--- a/Sources/Boutique/Store+Identifiable.swift
+++ b/Sources/Boutique/Store+Identifiable.swift
@@ -2,7 +2,8 @@ import Foundation
 
 public extension Store where Item: Identifiable, Item.ID == String {
 
-    /// Initializes a `Store` with a memory cache (represented by `items`), and a disk cache.
+    /// Initializes a `Store` with a memory cache and a disk cache.
+    /// 
     /// This initializer eschews providing a `cacheIdentifier` when our `Object` conforms to `Identifiable`
     /// with a `String` for it's `id`. While it's not required for your `Object` to conform to `Identifiable`,
     /// many SwiftUI-related objects do so this initializer provides a nice convenience.

--- a/Sources/Boutique/Store.CacheInvalidationStrategy.swift
+++ b/Sources/Boutique/Store.CacheInvalidationStrategy.swift
@@ -2,10 +2,12 @@ import Foundation
 
 public extension Store {
 
+    /// An invalidation strategy for a `Store` instance.
+    ///
+    /// ## Discussion
+    /// 
     /// A CacheInvalidationStrategy provides control over how old objects in the `Store`
     /// and disk cache are handled when new objects are added to the `Store`.
-    ///
-    /// For example:
     ///
     /// If you are downloading completely new data from the server and want to replace the current cache,
     /// a good strategy to choose would be `removeAll` to remove stale data.
@@ -19,7 +21,7 @@ public extension Store {
     /// but not remove all of videos that were cached in that time.
     /// (Get creative and create your own higher level strategies!)
     ///
-    /// 1: Even if you make additive changes with a policy like `removeNone` or `removeItems`,
+    /// Even if you make additive changes with a policy like `removeNone` or `removeItems`,
     /// if you cache a new version of an object with the same `cacheIdentifier`, the new object will replace the old item
     /// since you can only have one object per `cacheIdentifier`.
     enum CacheInvalidationStrategy<Object> {

--- a/Sources/Boutique/Stored.swift
+++ b/Sources/Boutique/Stored.swift
@@ -1,5 +1,6 @@
 import Combine
 
+/// A `@Stored` property wrapper to automagically initialize a `Store`.
 @propertyWrapper
 public struct Stored<Object: Codable & Equatable> {
 


### PR DESCRIPTION
The code already included plenty of in-source docs so this PR:

 - adds DocC curation so documentation is easy to navigate in Xcode and on the web
 - cleans up a few in-source doc comments so they render nicely as documentation
 - adds a config file so SwiftPackageIndex can automatically publish the documentation online

Here are some screenshots of the results:

- landing page

<img width="1518" alt="image" src="https://user-images.githubusercontent.com/633862/175246824-e99ae5ad-4848-4059-8bef-633e86160554.png">

- store page

<img width="1518" alt="image" src="https://user-images.githubusercontent.com/633862/175246918-079e64f9-3789-4c18-9da2-50668c21da58.png">

- getting started

<img width="1518" alt="image" src="https://user-images.githubusercontent.com/633862/175246974-29fa73f3-2b9a-4956-a933-fa3f62bb093a.png">
