### PR TITLE
Enabled concurrency checks and constrained Store to MainActor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,13 @@ let package = Package(
     targets: [
         .target(
             name: "Boutique",
-            dependencies: [.byName(name: "Bodega")]
+            dependencies: [.byName(name: "Bodega")],
+            swiftSettings: [
+                .unsafeFlags([
+                    "-Xfrontend", "-warn-concurrency",
+                    "-Xfrontend", "-enable-actor-data-race-checks",
+                ]),
+            ]
         ),
         .testTarget(
             name: "BoutiqueTests",
@@ -28,4 +34,3 @@ let package = Package(
         ),
     ]
 )
-

--- a/Sources/Boutique/Store+Identifiable.swift
+++ b/Sources/Boutique/Store+Identifiable.swift
@@ -7,8 +7,8 @@ public extension Store where Item: Identifiable, Item.ID == String {
     /// with a `String` for it's `id`. While it's not required for your `Object` to conform to `Identifiable`,
     /// many SwiftUI-related objects do so this initializer provides a nice convenience.
     /// - Parameter storagePath: A URL representing the folder on disk that your files will be written to.
-    convenience init(storagePath: URL) {
-        self.init(storagePath: storagePath, cacheIdentifier: \.id)
+    convenience init(storagePath: URL) async {
+        await self.init(storagePath: storagePath, cacheIdentifier: \.id)
     }
 
 }

--- a/Sources/Boutique/Store.swift
+++ b/Sources/Boutique/Store.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Under the hood the `Store` is doing the work of saving all changes to disk when you add or remove objects,
 /// which allows you to build an offline-first app for free, no extra code required.
 @MainActor
-public final class Store<Item: Codable & Equatable>: ObservableObject {
+public final class Store<Item: Codable & Equatable & Sendable>: ObservableObject {
 
     private let storagePath: URL
     private let objectStorage: ObjectStorage

--- a/Sources/Boutique/Stored.swift
+++ b/Sources/Boutique/Stored.swift
@@ -1,7 +1,7 @@
 import Combine
 
 @propertyWrapper
-public struct Stored<Object: Codable & Equatable> {
+public struct Stored<Object: Codable & Equatable & Sendable> {
 
     private let box: Box
 

--- a/Tests/BoutiqueTests/BoutiqueTests.swift
+++ b/Tests/BoutiqueTests/BoutiqueTests.swift
@@ -2,23 +2,22 @@
 import Combine
 import XCTest
 
+@MainActor
 final class BoutiqueTests: XCTestCase {
 
     private var store: Store<BoutiqueItem>!
     private var cancellables: Set<AnyCancellable> = []
 
     override func setUp() async throws {
-        store = Store<BoutiqueItem>(storagePath: Self.testStoragePath, cacheIdentifier: \.merchantID)
+        store = await Store<BoutiqueItem>(storagePath: Self.testStoragePath, cacheIdentifier: \.merchantID)
         try await store.removeAll()
     }
 
-    @MainActor
     func testAddingItem() async throws {
         try await store.add(Self.coat)
         XCTAssert(store.items.contains(Self.coat))
     }
 
-    @MainActor
     func testAddingItems() async throws {
         try await store.add([Self.coat, Self.sweater, Self.sweater, Self.purse])
         XCTAssert(store.items.contains(Self.coat))
@@ -26,26 +25,23 @@ final class BoutiqueTests: XCTestCase {
         XCTAssert(store.items.contains(Self.purse))
     }
 
-    @MainActor
     func testAddingDuplicateItems() async throws {
         XCTAssert(store.items.isEmpty)
         try await store.add(Self.allObjects)
-        XCTAssert(store.items.count == 4)
+        XCTAssertEqual(store.items.count, 4)
     }
 
-    @MainActor
     func testReadingItems() async throws {
         try await store.add(Self.allObjects)
 
-        XCTAssert(store.items[0] == Self.coat)
-        XCTAssert(store.items[1] == Self.sweater)
-        XCTAssert(store.items[2] == Self.purse)
-        XCTAssert(store.items[3] == Self.belt)
+        XCTAssertEqual(store.items[0], Self.coat)
+        XCTAssertEqual(store.items[1], Self.sweater)
+        XCTAssertEqual(store.items[2], Self.purse)
+        XCTAssertEqual(store.items[3], Self.belt)
 
         XCTAssert(store.items.count == 4)
     }
 
-    @MainActor
     func testRemovingItems() async throws {
         try await store.add(Self.allObjects)
         try await store.remove(Self.coat)
@@ -60,14 +56,13 @@ final class BoutiqueTests: XCTestCase {
         XCTAssertFalse(store.items.contains(Self.purse))
     }
 
-    @MainActor
     func testRemoveAll() async throws {
         try await store.add(Self.coat)
-        XCTAssert(store.items.count == 1)
+        XCTAssertEqual(store.items.count, 1)
         try await store.removeAll()
 
         try await store.add(Self.uniqueObjects)
-        XCTAssert(store.items.count == 4)
+        XCTAssertEqual(store.items.count, 4)
         try await store.removeAll()
         XCTAssert(store.items.isEmpty)
     }


### PR DESCRIPTION
After I enabled concurrency checks, the Store had many warnings because self is not Sendable but it was passed to MainActor.run {} closures. 

In SwiftUI, is generally recommended to mark ObservableObjects with @MainActor as far as I know.

After I made this change, some tests started to fail but I fixed them by making the init async. While this is a big change, I think it might make sense because when the Store is initialised, it loads the persisted state from disk, so until that happens, the Store is in an inconsistent state.

Some alternatives to @MainActor Store:
- Constrain Store to a different global actor
- Add @unchecked Sendable and hope everything is ok

Some alternatives to init async:
- Store a reference to the task that performs allPersistedItems() in init and make sure all the other methods await this task before doing their work.


Also, I changed some tests to use XCTAssertEqual because it provides a better error message.