### PR TITLE
Significant Performance Improvements

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mergesort/Bodega",
       "state" : {
-        "revision" : "2edf435448cda4e18a4850be7a9d03c0c79f5763",
-        "version" : "1.0.0"
+        "revision" : "29966bf638714c1fbe0c734e259b3d5dfda58d6b",
+        "version" : "1.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["Boutique"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/mergesort/Bodega.git", .upToNextMajor(from: "1.0.0"))
+        .package(url: "https://github.com/mergesort/Bodega.git", exact: Version(1, 0, 1))
     ],
     targets: [
         .target(

--- a/Sources/Boutique/Store.swift
+++ b/Sources/Boutique/Store.swift
@@ -1,5 +1,4 @@
 import Bodega
-import Combine
 import Foundation
 
 /// A general storage persistence layer.
@@ -15,7 +14,6 @@ public final class Store<Item: Codable & Equatable>: ObservableObject {
     private let storagePath: URL
     private let objectStorage: ObjectStorage
     private let cacheIdentifier: KeyPath<Item, String>
-    private var cancellables = Set<AnyCancellable>()
 
     /// The items held onto by the `Store`.
     ///

--- a/Sources/Boutique/Store.swift
+++ b/Sources/Boutique/Store.swift
@@ -39,15 +39,6 @@ public final class Store<Item: Codable & Equatable>: ObservableObject {
         self.objectStorage = ObjectStorage(storagePath: storagePath)
         self.cacheIdentifier = cacheIdentifier
 
-        self.$items
-            .removeDuplicates()
-            .sink(receiveValue: { items in
-                Task {
-                    try await self.persistItems(items)
-                }
-            })
-            .store(in: &cancellables)
-
         Task { @MainActor in
             self.items = await self.allPersistedItems()
         }
@@ -70,10 +61,10 @@ public final class Store<Item: Codable & Equatable>: ObservableObject {
     ///   - items: The items to add to the store.
     ///   - invalidationStrategy: An optional invalidation strategy for this add operation.
     public func add(_ items: [Item], invalidationStrategy: CacheInvalidationStrategy<Item> = .removeNone) async throws {
-        var currentItems: [Item] = await self.items
+        var updatedItems: [Item] = await self.items
 
         try await self.removePersistedItems(strategy: invalidationStrategy)
-        self.invalidateCache(strategy: invalidationStrategy, items: &currentItems)
+        self.invalidateCache(strategy: invalidationStrategy, items: &updatedItems)
 
         // Prevent duplicate values from being written multiple times.
         // This could cause a discrepancy between the data in memory
@@ -85,39 +76,32 @@ public final class Store<Item: Codable & Equatable>: ObservableObject {
         for item in uniqueItems {
             if let matchingIdentifierIndex = itemKeys.firstIndex(of: item[keyPath: self.cacheIdentifier]),
                case let matchingIdentifier = itemKeys[matchingIdentifierIndex],
-               let index = currentItems.firstIndex(where: { $0[keyPath: self.cacheIdentifier] == matchingIdentifier }) {
+               let index = updatedItems.firstIndex(where: { $0[keyPath: self.cacheIdentifier] == matchingIdentifier }) {
                     // We found a matching element with potentially different data so replace it in-place
-                    currentItems.remove(at: index)
-                    currentItems.insert(item, at: index)
+                    updatedItems.remove(at: index)
+                    updatedItems.insert(item, at: index)
                 } else {
                     // Append it to the cache if it doesn't already exist
-                    currentItems.append(item)
+                    updatedItems.append(item)
                 }
 
             itemKeys.removeAll(where: { $0 == item[keyPath: self.cacheIdentifier] })
         }
 
-        // We can't capture a mutable array (currentItems) in the closure below so we make an immutable copy.
+        try await self.persistItems(updatedItems)
+
+        // We can't capture a mutable array (updatedItems) in the closure below so we make an immutable copy.
         // An implicitly captured closure variable is captured by reference while
         // a variable captured in the capture group is captured by value.
-        await MainActor.run { [currentItems] in
-            self.items = currentItems
+        await MainActor.run { [updatedItems] in
+            self.items = updatedItems
         }
     }
 
     /// Removes an item from the store.
     /// - Parameter item: The item you are removing from the `Store`.
     public func remove(_ item: Item) async throws {
-        let itemKey = item[keyPath: self.cacheIdentifier]
-        let cacheKey = CacheKey(itemKey)
-
-        try await self.removePersistedItem(forKey: cacheKey)
-
-        await MainActor.run {
-            self.items.removeAll(where: {
-                itemKey == $0[keyPath: self.cacheIdentifier]
-            })
-        }
+        try await self.remove([item])
     }
 
     /// Removes a list of items from the store.
@@ -126,12 +110,9 @@ public final class Store<Item: Codable & Equatable>: ObservableObject {
     /// avoid making multiple separate dispatches to the `@MainActor`.
     /// - Parameter item: The items you are removing from the `Store`.
     public func remove(_ items: [Item]) async throws {
-        let itemKeys = items.map { $0[keyPath: self.cacheIdentifier] }
-        let cacheKeys = itemKeys.map({ CacheKey($0) })
+        let itemKeys = items.map({ $0[keyPath: self.cacheIdentifier] })
 
-        for cacheKey in cacheKeys {
-            try await self.removePersistedItem(forKey: cacheKey)
-        }
+        try await self.removePersistedItems(items: items)
 
         await MainActor.run {
             self.items.removeAll(where: { item in
@@ -174,8 +155,13 @@ private extension Store {
         }
     }
 
-    func removePersistedItem(forKey cacheKey: CacheKey) async throws {
-        try await self.objectStorage.removeObject(forKey: cacheKey)
+    func removePersistedItems(items: [Item]) async throws {
+        let itemKeys = items.map({ $0[keyPath: self.cacheIdentifier] })
+            .map({ CacheKey($0) })
+
+        for cacheKey in itemKeys {
+            try await self.objectStorage.removeObject(forKey: cacheKey)
+        }
     }
 
     func removeAllPersistedItems() async throws {

--- a/Sources/Boutique/Store.swift
+++ b/Sources/Boutique/Store.swift
@@ -88,7 +88,7 @@ public final class Store<Item: Codable & Equatable>: ObservableObject {
             itemKeys.removeAll(where: { $0 == item[keyPath: self.cacheIdentifier] })
         }
 
-        try await self.persistItems(updatedItems)
+        try await self.persistItems(uniqueItems)
 
         // We can't capture a mutable array (updatedItems) in the closure below so we make an immutable copy.
         // An implicitly captured closure variable is captured by reference while


### PR DESCRIPTION
This patch offers many fixes to performance based on the thoughts, ideas, and suggestions provided in #14.

As always it's the code you write that causes problems and the code you don't write that solves problems. It turns out I was creating many unnecessary writes on startup launch and additionally every time an item was added to the Store. This became a worse and worse problem as a Store grew, impacting startup time and performance of writing or removing items from a large Store.

Now startup time is dramatically improved, testing in a profiler app I built I was able to get launch time for a Store with 8,000 objects from 15 seconds down to somewhere between 1-2 seconds. For small Stores the launch time is practically nothing.

There are also no longer any performance penalties for adding objects to a large Store. This is due to the fact we're no longer rewriting every item in the Store (duh), only writing a the new items that were added to the store. You can expect the same for remove operations.

Removing the `sink` that was performing the unnecessary rewrites also means being able to remove the dependency on Combine, which removes the necessity for solving #1.

As important as all the performance improvements, the code is now significantly simpler and easier to follow. Thank you to @pofat for providing all of your thoughts and suggestions, Boutique is better for it and I am very happy to have had your help! 🙂