### PR TITLE
Add optional sortBy function

### DIFF
--- a/Demo/Demo/App/App.Store.swift
+++ b/Demo/Demo/App/App.Store.swift
@@ -25,7 +25,8 @@ extension Store where Item == RemoteImage {
     /// but with your very own data layer. You can even endlessly compose `StorageEngine`s to create a
     /// complex data pipeline that hits your API and saves items into a database, all in one API call.
     static let imagesStore = Store<RemoteImage>(
-        storage: SQLiteStorageEngine.default(appendingPath: "Images")
+        storage: SQLiteStorageEngine.default(appendingPath: "Images"),
+        sortBy: { $0.createdAt > $1.createdAt }
     )
 
 }

--- a/Demo/Demo/Components/FavoritesCarouselView.swift
+++ b/Demo/Demo/Components/FavoritesCarouselView.swift
@@ -150,7 +150,7 @@ struct FavoritesCarouselView: View {
             }
         }
         .onReceive(self.imagesController.$images.$items, perform: {
-            self.images = $0.sorted(by: { $0.createdAt > $1.createdAt})
+            self.images = $0
         })
         .frame(height: 200.0)
         .background(Color.palette.background)

--- a/Sources/Boutique/Store+Identifiable.swift
+++ b/Sources/Boutique/Store+Identifiable.swift
@@ -8,8 +8,9 @@ public extension Store where Item: Identifiable, Item.ID == String {
     /// with an `id` that is a `String`. While it's not required for your `Item` to conform to `Identifiable`,
     /// many SwiftUI-related objects do so this initializer provides a nice convenience.
     /// - Parameter storage: A `StorageEngine` to initialize a ``Store`` instance with.
-    convenience init(storage: StorageEngine) {
-        self.init(storage: storage, cacheIdentifier: \.id)
+    /// - Parameter sortBy: An optional function that the ``Store`` uses to keep the items added to it sorted
+    convenience init(storage: StorageEngine, sortBy: ((Item, Item) -> Bool)? = nil) {
+        self.init(storage: storage, cacheIdentifier: \.id, sortBy: sortBy)
     }
 
 }
@@ -22,8 +23,9 @@ public extension Store where Item: Identifiable, Item.ID == UUID {
     /// with an `id` that is a `UUID`. While it's not required for your `Item` to conform to `Identifiable`,
     /// many SwiftUI-related objects do so this initializer provides a nice convenience.
     /// - Parameter storage: A `StorageEngine` to initialize a ``Store`` instance with.
-    convenience init(storage: StorageEngine) {
-        self.init(storage: storage, cacheIdentifier: \.id.uuidString)
+    /// - Parameter sortBy: An optional function that the ``Store`` uses to keep the items added to it sorted
+    convenience init(storage: StorageEngine, sortBy: ((Item, Item) -> Bool)? = nil) {
+        self.init(storage: storage, cacheIdentifier: \.id.uuidString, sortBy: sortBy)
     }
 
 }


### PR DESCRIPTION
# Why

Currently the sorting of elements returned from the `Store` is done adhoc. The Demo code does this inside the view layer.

For the use case I have in mind, the sorting logic is a bit more complex _and_ the same store is used in several places throughout the app. Duplicating the sorting logic in several places like this doesn't seem like a good idea.

# How

The PR adds an optional `sortBy: (Item, Item) -> Bool` function to the `Store`.