### PR TITLE
Add `init(...) async throws` overloads to the `Store`.

### DIFF
--- a/Sources/Boutique/Documentation.docc/Articles/Using Stores.md
+++ b/Sources/Boutique/Documentation.docc/Articles/Using Stores.md
@@ -84,6 +84,35 @@ try await store
     .run()
 ```
 
+
+## Sync or Async?
+
+To work with @``Stored`` or other 3rd party property wrappers, the ``Store`` has to be initialized synchronously, which means that the `items` are loaded in the background. However this can be an issue if you are using the ``Store`` directly and need to show the content on launch. The ``Store`` provides you with two options to handle this:
+
+By using the `async` overload of the `init`, which returns the store once the `items` are loaded. 
+```swift
+let store: Store<YourItem>
+
+init() async throws {
+    store = try await Store(...)
+    // Now the store will have `items` already loaded.
+    let items = await store.items
+}
+```
+
+Or you could still use the regular synchronous `Store.init` and then await for items to load before accessing them:
+```swift
+let store: Store<YourItem> = Store(...)
+
+func getItems() async -> [YourItem] {
+    try await store.itemsHaveLoaded() 
+    return await store.items
+}
+```
+
+There is no "preferred" approach here, these tools are simply there to help you use the ``Store`` regardless of _how_ you use it.
+
+
 ## Further Exploration, @Stored And More
 
 Building an app using the ``Store`` can be really powerful because it leans into SwiftUI's state-driven architecture, while providing you with offline-first capabilities, realtime updates across your app, with almost no additional code required.

--- a/Sources/Boutique/Documentation.docc/Articles/Using Stores.md
+++ b/Sources/Boutique/Documentation.docc/Articles/Using Stores.md
@@ -87,11 +87,12 @@ try await store
 
 ## Sync or Async?
 
-To work with @``Stored`` or other 3rd party property wrappers, the ``Store`` has to be initialized synchronously, which means that the `items` are loaded in the background. However this can be an issue if you are using the ``Store`` directly and need to show the content on launch. The ``Store`` provides you with two options to handle this:
+To work with @``Stored`` or alternative property wrappers the ``Store`` must be initialized synchronously. This means that the `items` of your ``Store`` will be loaded in the background, and may not be available immediately. However this can be an issue if you are using the ``Store`` directly and need to show the contents of the ``Store`` immediately, such as on your app's launch'. The ``Store`` provides you with two options to handle a scenario like this.
 
-By using the `async` overload of the `init`, which returns the store once the `items` are loaded. 
+By using the `async` overload of the ``Store`` initializer your ``Store`` will be returned once all of the `items` are loaded.
+
 ```swift
-let store: Store<YourItem>
+let store: Store<Item>
 
 init() async throws {
     store = try await Store(...)
@@ -100,18 +101,18 @@ init() async throws {
 }
 ```
 
-Or you could still use the regular synchronous `Store.init` and then await for items to load before accessing them:
-```swift
-let store: Store<YourItem> = Store(...)
+Alternatively you can use the synchronous initializer, and then await for items to load before accessing them.
 
-func getItems() async -> [YourItem] {
+```swift
+let store: Store<Item> = Store(...)
+
+func getItems() async -> [Item] {
     try await store.itemsHaveLoaded() 
     return await store.items
 }
 ```
 
-There is no "preferred" approach here, these tools are simply there to help you use the ``Store`` regardless of _how_ you use it.
-
+The synchronous initializer is a sensible default, but if your app's needs dictate displaying data only once you've loaded all of the necessary items the asynchronous initializers are there to help.
 
 ## Further Exploration, @Stored And More
 

--- a/Sources/Boutique/Store+Identifiable.swift
+++ b/Sources/Boutique/Store+Identifiable.swift
@@ -12,10 +12,10 @@ public extension Store where Item: Identifiable, Item.ID == String {
     /// ```
     /// let store: Store<YourItem>
     ///
-    /// init() async {
-    ///   store = try await Store(...)
-    ///   let items = await store.items
-    ///   // use `items`...
+    /// init() async throws {
+    ///     store = try await Store(...)
+    ///     // Now the store will have `items` already loaded.
+    ///     let items = await store.items
     /// }
     /// ```
     ///
@@ -60,10 +60,10 @@ public extension Store where Item: Identifiable, Item.ID == UUID {
     /// ```
     /// let store: Store<YourItem>
     ///
-    /// init() async {
-    ///   store = try await Store(...)
-    ///   let items = await store.items
-    ///   // use `items`...
+    /// init() async throws {
+    ///     store = try await Store(...)
+    ///     // Now the store will have `items` already loaded.
+    ///     let items = await store.items
     /// }
     /// ```
     ///

--- a/Sources/Boutique/Store+Identifiable.swift
+++ b/Sources/Boutique/Store+Identifiable.swift
@@ -22,6 +22,7 @@ public extension Store where Item: Identifiable, Item.ID == String {
     /// - Wait for items to be loaded before accessing them:
     /// ```
     /// let store: Store<YourItem> = Store(...)
+    ///
     /// func getItems() async -> [YourItem] {
     ///     try await store.itemsHaveLoaded()
     ///     return await store.items
@@ -69,6 +70,7 @@ public extension Store where Item: Identifiable, Item.ID == UUID {
     /// - Wait for items to be loaded before accessing them:
     /// ```
     /// let store: Store<YourItem> = Store(...)
+    /// 
     /// func getItems() async -> [YourItem] {
     ///     try await store.itemsHaveLoaded()
     ///     return await store.items

--- a/Sources/Boutique/Store+Identifiable.swift
+++ b/Sources/Boutique/Store+Identifiable.swift
@@ -4,17 +4,20 @@ public extension Store where Item: Identifiable, Item.ID == String {
 
     /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth.
     ///
-    /// The items will be loaded asynchronously in a background task. If you need to show the
-    /// content of the Store right away, you have two options:
+    /// The items will be loaded asynchronously in a background task. If you are not using this with
+    /// `Stored` and need to show the content of the Store right away, you have two options:
     ///
-    /// - Move the initialization to an `async` context, so you can use the `async` version of the init:
+    /// - Move the Store initialization to an `async` context, so the `Store.init` returns only
+    /// once items have been loaded:
     /// ```
-    /// func loadStore() async {
-    ///     let store = try await Store(...)
-    ///     let items = await store.items
+    /// let store: Store<YourItem>
+    ///
+    /// init() async {
+    ///   store = try await Store(...)
+    ///   let items = await store.items
+    ///   // use `items`...
     /// }
     /// ```
-    /// This will return the store only when items have been loaded.
     ///
     /// - Wait for items to be loaded before accessing them:
     /// ```
@@ -48,17 +51,20 @@ public extension Store where Item: Identifiable, Item.ID == UUID {
 
     /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth.
     ///
-    /// The items will be loaded asynchronously in a background task. If you need to show the
-    /// content of the Store right away, you have two options:
+    /// The items will be loaded asynchronously in a background task. If you are not using this with
+    /// `Stored` and need to show the content of the Store right away, you have two options:
     ///
-    /// - Move the initialization to an `async` context, so you can use the `async` version of the init:
+    /// - Move the Store initialization to an `async` context, so the `Store.init` returns only
+    /// once items have been loaded:
     /// ```
-    /// func loadStore() async {
-    ///     let store = try await Store(...)
-    ///     let items = await store.items
+    /// let store: Store<YourItem>
+    ///
+    /// init() async {
+    ///   store = try await Store(...)
+    ///   let items = await store.items
+    ///   // use `items`...
     /// }
     /// ```
-    /// This will return the store only when items have been loaded.
     ///
     /// - Wait for items to be loaded before accessing them:
     /// ```

--- a/Sources/Boutique/Store+Identifiable.swift
+++ b/Sources/Boutique/Store+Identifiable.swift
@@ -19,8 +19,8 @@ public extension Store where Item: Identifiable, Item.ID == String {
     /// with an `id` that is a `String`. While it's not required for your `Item` to conform to `Identifiable`,
     /// many SwiftUI-related objects do so this initializer provides a nice convenience.
     /// - Parameter storage: A `StorageEngine` to initialize a ``Store`` instance with.
-    convenience init(storage: StorageEngine) async {
-        await self.init(storage: storage, cacheIdentifier: \.id)
+    convenience init(storage: StorageEngine) async throws {
+        try await self.init(storage: storage, cacheIdentifier: \.id)
     }
 }
 
@@ -42,7 +42,7 @@ public extension Store where Item: Identifiable, Item.ID == UUID {
     /// with an `id` that is a `UUID`. While it's not required for your `Item` to conform to `Identifiable`,
     /// many SwiftUI-related objects do so this initializer provides a nice convenience.
     /// - Parameter storage: A `StorageEngine` to initialize a ``Store`` instance with.
-    convenience init(storage: StorageEngine) async {
-        await self.init(storage: storage, cacheIdentifier: \.id.uuidString)
+    convenience init(storage: StorageEngine) async throws {
+        try await self.init(storage: storage, cacheIdentifier: \.id.uuidString)
     }
 }

--- a/Sources/Boutique/Store+Identifiable.swift
+++ b/Sources/Boutique/Store+Identifiable.swift
@@ -3,7 +3,7 @@ import Foundation
 public extension Store where Item: Identifiable, Item.ID == String {
 
     /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth.
-    /// The content will be loaded asynchronously on a background task.
+    /// The items will be loaded asynchronously on a background task.
     ///
     /// This initializer eschews providing a `cacheIdentifier` when our `Item` conforms to `Identifiable`
     /// with an `id` that is a `String`. While it's not required for your `Item` to conform to `Identifiable`,
@@ -27,7 +27,7 @@ public extension Store where Item: Identifiable, Item.ID == String {
 public extension Store where Item: Identifiable, Item.ID == UUID {
 
     /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth.
-    /// The content will be loaded asynchronously on a background task.
+    /// The items will be loaded asynchronously on a background task.
     ///
     /// This initializer eschews providing a `cacheIdentifier` when our `Item` conforms to `Identifiable`
     /// with an `id` that is a `UUID`. While it's not required for your `Item` to conform to `Identifiable`,

--- a/Sources/Boutique/Store+Identifiable.swift
+++ b/Sources/Boutique/Store+Identifiable.swift
@@ -3,6 +3,7 @@ import Foundation
 public extension Store where Item: Identifiable, Item.ID == String {
 
     /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth.
+    /// The content will be loaded asynchronously on a background task.
     ///
     /// This initializer eschews providing a `cacheIdentifier` when our `Item` conforms to `Identifiable`
     /// with an `id` that is a `String`. While it's not required for your `Item` to conform to `Identifiable`,
@@ -11,12 +12,22 @@ public extension Store where Item: Identifiable, Item.ID == String {
     convenience init(storage: StorageEngine) {
         self.init(storage: storage, cacheIdentifier: \.id)
     }
-
+    
+    /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth.
+    ///
+    /// This initializer eschews providing a `cacheIdentifier` when our `Item` conforms to `Identifiable`
+    /// with an `id` that is a `String`. While it's not required for your `Item` to conform to `Identifiable`,
+    /// many SwiftUI-related objects do so this initializer provides a nice convenience.
+    /// - Parameter storage: A `StorageEngine` to initialize a ``Store`` instance with.
+    convenience init(storage: StorageEngine) async {
+        await self.init(storage: storage, cacheIdentifier: \.id)
+    }
 }
 
 public extension Store where Item: Identifiable, Item.ID == UUID {
 
     /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth.
+    /// The content will be loaded asynchronously on a background task.
     ///
     /// This initializer eschews providing a `cacheIdentifier` when our `Item` conforms to `Identifiable`
     /// with an `id` that is a `UUID`. While it's not required for your `Item` to conform to `Identifiable`,
@@ -25,5 +36,13 @@ public extension Store where Item: Identifiable, Item.ID == UUID {
     convenience init(storage: StorageEngine) {
         self.init(storage: storage, cacheIdentifier: \.id.uuidString)
     }
-
+    /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth.
+    ///
+    /// This initializer eschews providing a `cacheIdentifier` when our `Item` conforms to `Identifiable`
+    /// with an `id` that is a `UUID`. While it's not required for your `Item` to conform to `Identifiable`,
+    /// many SwiftUI-related objects do so this initializer provides a nice convenience.
+    /// - Parameter storage: A `StorageEngine` to initialize a ``Store`` instance with.
+    convenience init(storage: StorageEngine) async {
+        await self.init(storage: storage, cacheIdentifier: \.id.uuidString)
+    }
 }

--- a/Sources/Boutique/Store+Identifiable.swift
+++ b/Sources/Boutique/Store+Identifiable.swift
@@ -13,7 +13,7 @@ public extension Store where Item: Identifiable, Item.ID == String {
         self.init(storage: storage, cacheIdentifier: \.id)
     }
     
-    /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth.
+    /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth, and await for the ``items`` to load.
     ///
     /// This initializer eschews providing a `cacheIdentifier` when our `Item` conforms to `Identifiable`
     /// with an `id` that is a `String`. While it's not required for your `Item` to conform to `Identifiable`,
@@ -36,7 +36,7 @@ public extension Store where Item: Identifiable, Item.ID == UUID {
     convenience init(storage: StorageEngine) {
         self.init(storage: storage, cacheIdentifier: \.id.uuidString)
     }
-    /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth.
+    /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth, and await for the ``items`` to load.
     ///
     /// This initializer eschews providing a `cacheIdentifier` when our `Item` conforms to `Identifiable`
     /// with an `id` that is a `UUID`. While it's not required for your `Item` to conform to `Identifiable`,

--- a/Sources/Boutique/Store+Identifiable.swift
+++ b/Sources/Boutique/Store+Identifiable.swift
@@ -3,7 +3,27 @@ import Foundation
 public extension Store where Item: Identifiable, Item.ID == String {
 
     /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth.
-    /// The items will be loaded asynchronously in a background task.
+    ///
+    /// The items will be loaded asynchronously in a background task. If you need to show the
+    /// content of the Store right away, you have two options:
+    ///
+    /// - Move the initialization to an `async` context, so you can use the `async` version of the init:
+    /// ```
+    /// func loadStore() async {
+    ///     let store = try await Store(...)
+    ///     let items = await store.items
+    /// }
+    /// ```
+    /// This will return the store only when items have been loaded.
+    ///
+    /// - Wait for items to be loaded before accessing them:
+    /// ```
+    /// let store: Store<YourItem> = Store(...)
+    /// func getItems() async -> [YourItem] {
+    ///     try await store.itemsHaveLoaded()
+    ///     return await store.items
+    /// }
+    /// ```
     ///
     /// This initializer eschews providing a `cacheIdentifier` when our `Item` conforms to `Identifiable`
     /// with an `id` that is a `String`. While it's not required for your `Item` to conform to `Identifiable`,
@@ -27,7 +47,27 @@ public extension Store where Item: Identifiable, Item.ID == String {
 public extension Store where Item: Identifiable, Item.ID == UUID {
 
     /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth.
-    /// The items will be loaded asynchronously in a background task.
+    ///
+    /// The items will be loaded asynchronously in a background task. If you need to show the
+    /// content of the Store right away, you have two options:
+    ///
+    /// - Move the initialization to an `async` context, so you can use the `async` version of the init:
+    /// ```
+    /// func loadStore() async {
+    ///     let store = try await Store(...)
+    ///     let items = await store.items
+    /// }
+    /// ```
+    /// This will return the store only when items have been loaded.
+    ///
+    /// - Wait for items to be loaded before accessing them:
+    /// ```
+    /// let store: Store<YourItem> = Store(...)
+    /// func getItems() async -> [YourItem] {
+    ///     try await store.itemsHaveLoaded()
+    ///     return await store.items
+    /// }
+    /// ```
     ///
     /// This initializer eschews providing a `cacheIdentifier` when our `Item` conforms to `Identifiable`
     /// with an `id` that is a `UUID`. While it's not required for your `Item` to conform to `Identifiable`,

--- a/Sources/Boutique/Store+Identifiable.swift
+++ b/Sources/Boutique/Store+Identifiable.swift
@@ -4,13 +4,15 @@ public extension Store where Item: Identifiable, Item.ID == String {
 
     /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth.
     ///
-    /// The items will be loaded asynchronously in a background task. If you are not using this with
-    /// `Stored` and need to show the content of the Store right away, you have two options:
+    /// The ``items`` will be loaded asynchronously in a background task.
+    /// If you are not using this with @``Stored`` and need to show
+    /// the contents of the Store right away, you have two options.
     ///
-    /// - Move the Store initialization to an `async` context, so the `Store.init` returns only
-    /// once items have been loaded:
+    /// - Move the ``Store`` initialization to an `async` context
+    ///  so `init` returns only once items have been loaded.
+    ///
     /// ```
-    /// let store: Store<YourItem>
+    /// let store: Store<Item>
     ///
     /// init() async throws {
     ///     store = try await Store(...)
@@ -19,11 +21,13 @@ public extension Store where Item: Identifiable, Item.ID == String {
     /// }
     /// ```
     ///
-    /// - Wait for items to be loaded before accessing them:
-    /// ```
-    /// let store: Store<YourItem> = Store(...)
+    /// - Alternatively you can use the synchronous initializer
+    /// and then await for items to load before accessing them.
     ///
-    /// func getItems() async -> [YourItem] {
+    /// ```
+    /// let store: Store<Item> = Store(...)
+    ///
+    /// func getItems() async -> [Item] {
     ///     try await store.itemsHaveLoaded()
     ///     return await store.items
     /// }
@@ -38,10 +42,6 @@ public extension Store where Item: Identifiable, Item.ID == String {
     }
     
     /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth, and await for the ``items`` to load.
-    ///
-    /// This initializer eschews providing a `cacheIdentifier` when our `Item` conforms to `Identifiable`
-    /// with an `id` that is a `String`. While it's not required for your `Item` to conform to `Identifiable`,
-    /// many SwiftUI-related objects do so this initializer provides a nice convenience.
     /// - Parameter storage: A `StorageEngine` to initialize a ``Store`` instance with.
     convenience init(storage: StorageEngine) async throws {
         try await self.init(storage: storage, cacheIdentifier: \.id)
@@ -52,13 +52,15 @@ public extension Store where Item: Identifiable, Item.ID == UUID {
 
     /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth.
     ///
-    /// The items will be loaded asynchronously in a background task. If you are not using this with
-    /// `Stored` and need to show the content of the Store right away, you have two options:
+    /// The ``items`` will be loaded asynchronously in a background task.
+    /// If you are not using this with @``Stored`` and need to show
+    /// the contents of the Store right away, you have two options.
     ///
-    /// - Move the Store initialization to an `async` context, so the `Store.init` returns only
-    /// once items have been loaded:
+    /// - Move the ``Store`` initialization to an `async` context
+    ///  so `init` returns only once items have been loaded.
+    ///
     /// ```
-    /// let store: Store<YourItem>
+    /// let store: Store<Item>
     ///
     /// init() async throws {
     ///     store = try await Store(...)
@@ -67,11 +69,13 @@ public extension Store where Item: Identifiable, Item.ID == UUID {
     /// }
     /// ```
     ///
-    /// - Wait for items to be loaded before accessing them:
+    /// - Alternatively you can use the synchronous initializer
+    /// and then await for items to load before accessing them.
+    /// 
     /// ```
-    /// let store: Store<YourItem> = Store(...)
-    /// 
-    /// func getItems() async -> [YourItem] {
+    /// let store: Store<Item> = Store(...)
+    ///
+    /// func getItems() async -> [Item] {
     ///     try await store.itemsHaveLoaded()
     ///     return await store.items
     /// }

--- a/Sources/Boutique/Store+Identifiable.swift
+++ b/Sources/Boutique/Store+Identifiable.swift
@@ -3,7 +3,7 @@ import Foundation
 public extension Store where Item: Identifiable, Item.ID == String {
 
     /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth.
-    /// The items will be loaded asynchronously on a background task.
+    /// The items will be loaded asynchronously in a background task.
     ///
     /// This initializer eschews providing a `cacheIdentifier` when our `Item` conforms to `Identifiable`
     /// with an `id` that is a `String`. While it's not required for your `Item` to conform to `Identifiable`,
@@ -27,7 +27,7 @@ public extension Store where Item: Identifiable, Item.ID == String {
 public extension Store where Item: Identifiable, Item.ID == UUID {
 
     /// Initializes a new ``Store`` for persisting items to a memory cache and a storage engine, acting as a source of truth.
-    /// The items will be loaded asynchronously on a background task.
+    /// The items will be loaded asynchronously in a background task.
     ///
     /// This initializer eschews providing a `cacheIdentifier` when our `Item` conforms to `Identifiable`
     /// with an `id` that is a `UUID`. While it's not required for your `Item` to conform to `Identifiable`,

--- a/Sources/Boutique/Store.swift
+++ b/Sources/Boutique/Store.swift
@@ -72,10 +72,10 @@ public final class Store<Item: Codable & Equatable>: ObservableObject {
     /// ```
     /// let store: Store<YourItem>
     ///
-    /// init() async {
-    ///   store = try await Store(...)
-    ///   let items = await store.items
-    ///   // use `items`...
+    /// init() async throws {
+    ///     store = try await Store(...)
+    ///     // Now the store will have `items` already loaded.
+    ///     let items = await store.items
     /// }
     /// ```
     ///
@@ -110,7 +110,7 @@ public final class Store<Item: Codable & Equatable>: ObservableObject {
     public init(storage: StorageEngine, cacheIdentifier: KeyPath<Item, String>) async throws {
         self.storageEngine = storage
         self.cacheIdentifier = cacheIdentifier
-        try await loadStoreTask.value
+        try await itemsHaveLoaded()
     }
 
     /// Awaits for `items` to be loaded.

--- a/Sources/Boutique/Store.swift
+++ b/Sources/Boutique/Store.swift
@@ -64,17 +64,20 @@ public final class Store<Item: Codable & Equatable>: ObservableObject {
     /// Initializes a new ``Store`` for persisting items to a memory cache
     /// and a storage engine, to act as a source of truth.
     ///
-    /// The items will be loaded asynchronously in a background task. If you need to show the
-    /// content of the Store right away, you have two options:
+    /// The items will be loaded asynchronously in a background task. If you are not using this with
+    /// `Stored` and need to show the content of the Store right away, you have two options:
     ///
-    /// - Move the initialization to an `async` context, so you can use the `async` version of the init:
+    /// - Move the Store initialization to an `async` context, so the `Store.init` returns only
+    /// once items have been loaded:
     /// ```
-    /// func loadStore() async {
-    ///     let store = try await Store(...)
-    ///     let items = await store.items
+    /// let store: Store<YourItem>
+    ///
+    /// init() async {
+    ///   store = try await Store(...)
+    ///   let items = await store.items
+    ///   // use `items`...
     /// }
     /// ```
-    /// This will return the store only when items have been loaded.
     ///
     /// - Wait for items to be loaded before accessing them:
     /// ```

--- a/Sources/Boutique/Store.swift
+++ b/Sources/Boutique/Store.swift
@@ -57,7 +57,7 @@ public final class Store<Item: Codable & Equatable>: ObservableObject {
 
     /// Initializes a new ``Store`` for persisting items to a memory cache
     /// and a storage engine, to act as a source of truth. The items will be loaded
-    /// asynchronously on a background task.
+    /// asynchronously in a background task.
     ///
     /// - Parameters:
     ///   - storage: A `StorageEngine` to initialize a ``Store`` instance with.

--- a/Sources/Boutique/Store.swift
+++ b/Sources/Boutique/Store.swift
@@ -56,7 +56,7 @@ public final class Store<Item: Codable & Equatable>: ObservableObject {
     @MainActor @Published public private(set) var items: [Item] = []
 
     /// Initializes a new ``Store`` for persisting items to a memory cache
-    /// and a storage engine, to act as a source of truth. The content will be loaded
+    /// and a storage engine, to act as a source of truth. The items will be loaded
     /// asynchronously on a background task.
     ///
     /// - Parameters:

--- a/Sources/Boutique/Store.swift
+++ b/Sources/Boutique/Store.swift
@@ -82,6 +82,7 @@ public final class Store<Item: Codable & Equatable>: ObservableObject {
     /// - Wait for items to be loaded before accessing them:
     /// ```
     /// let store: Store<YourItem> = Store(...)
+    ///
     /// func getItems() async -> [YourItem] {
     ///     try await store.itemsHaveLoaded()
     ///     return await store.items
@@ -105,8 +106,8 @@ public final class Store<Item: Codable & Equatable>: ObservableObject {
     ///   - storage: A `StorageEngine` to initialize a ``Store`` instance with.
     ///   - cacheIdentifier: A `KeyPath` from the `Item` pointing to a `String`, which the ``Store``
     ///   will use to create a unique identifier for the item when it's saved.
-    @_disfavoredOverload
-    @MainActor public init(storage: StorageEngine, cacheIdentifier: KeyPath<Item, String>) async throws {
+    @MainActor
+    public init(storage: StorageEngine, cacheIdentifier: KeyPath<Item, String>) async throws {
         self.storageEngine = storage
         self.cacheIdentifier = cacheIdentifier
         try await loadStoreTask.value

--- a/Sources/Boutique/Store.swift
+++ b/Sources/Boutique/Store.swift
@@ -77,7 +77,7 @@ public final class Store<Item: Codable & Equatable>: ObservableObject {
             }
         }
     }
-  
+
     /// Initializes a new ``Store`` for persisting items to a memory cache
     /// and a storage engine, to act as a source of truth.
     ///
@@ -85,14 +85,13 @@ public final class Store<Item: Codable & Equatable>: ObservableObject {
     ///   - storage: A `StorageEngine` to initialize a ``Store`` instance with.
     ///   - cacheIdentifier: A `KeyPath` from the `Item` pointing to a `String`, which the ``Store``
     ///   will use to create a unique identifier for the item when it's saved.
-    @MainActor
-    public init(storage: StorageEngine, cacheIdentifier: KeyPath<Item, String>) async throws {
-      self.storageEngine = storage
-      self.cacheIdentifier = cacheIdentifier
-      
-      let decoder = JSONDecoder()
-      self.items = try await self.storageEngine.readAllData()
-        .map({ try decoder.decode(Item.self, from: $0) })
+    @MainActor public init(storage: StorageEngine, cacheIdentifier: KeyPath<Item, String>) async throws {
+        self.storageEngine = storage
+        self.cacheIdentifier = cacheIdentifier
+
+        let decoder = JSONDecoder()
+        self.items = try await self.storageEngine.readAllData()
+            .map({ try decoder.decode(Item.self, from: $0) })
     }
 
     /// Adds an item to the store.

--- a/Sources/Boutique/Store.swift
+++ b/Sources/Boutique/Store.swift
@@ -86,17 +86,13 @@ public final class Store<Item: Codable & Equatable>: ObservableObject {
     ///   - cacheIdentifier: A `KeyPath` from the `Item` pointing to a `String`, which the ``Store``
     ///   will use to create a unique identifier for the item when it's saved.
     @MainActor
-    public init(storage: StorageEngine, cacheIdentifier: KeyPath<Item, String>) async {
-        self.storageEngine = storage
-        self.cacheIdentifier = cacheIdentifier
-        
-        do {
-            let decoder = JSONDecoder()
-            self.items = try await self.storageEngine.readAllData()
-                .map({ try decoder.decode(Item.self, from: $0) })
-        } catch {
-            self.items = []
-        }
+    public init(storage: StorageEngine, cacheIdentifier: KeyPath<Item, String>) async throws {
+      self.storageEngine = storage
+      self.cacheIdentifier = cacheIdentifier
+      
+      let decoder = JSONDecoder()
+      self.items = try await self.storageEngine.readAllData()
+        .map({ try decoder.decode(Item.self, from: $0) })
     }
 
     /// Adds an item to the store.

--- a/Sources/Boutique/StoredValue+Dictionary.swift
+++ b/Sources/Boutique/StoredValue+Dictionary.swift
@@ -44,5 +44,4 @@ public extension AsyncStoredValue {
         try await self.set(updatedDictionary)
     }
 
-
 }

--- a/Tests/BoutiqueTests/AsyncStoreTests.swift
+++ b/Tests/BoutiqueTests/AsyncStoreTests.swift
@@ -1,0 +1,236 @@
+@testable import Boutique
+import Combine
+import XCTest
+
+final class AsyncStoreTests: XCTestCase {
+    
+    private var asyncStore: Store<BoutiqueItem>!
+    private var cancellables: Set<AnyCancellable> = []
+    
+    override func setUp() async throws {
+        asyncStore = try await Store<BoutiqueItem>(
+            storage: SQLiteStorageEngine.default(appendingPath: "Tests"),
+            cacheIdentifier: \.merchantID)
+        try await asyncStore.removeAll()
+    }
+    
+    override func tearDown() {
+        cancellables.removeAll()
+    }
+    
+    @MainActor
+    func testInsertingItem() async throws {
+        try await asyncStore.insert(BoutiqueItem.coat)
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.coat))
+        
+        try await asyncStore.insert(BoutiqueItem.belt)
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.belt))
+        XCTAssertEqual(asyncStore.items.count, 2)
+    }
+    
+    @MainActor
+    func testInsertingItems() async throws {
+        try await asyncStore.insert([BoutiqueItem.coat, BoutiqueItem.sweater, BoutiqueItem.sweater, BoutiqueItem.purse])
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.coat))
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.sweater))
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.purse))
+    }
+    
+    @MainActor
+    func testInsertingDuplicateItems() async throws {
+        XCTAssertTrue(asyncStore.items.isEmpty)
+        try await asyncStore.insert(BoutiqueItem.allItems)
+        XCTAssertEqual(asyncStore.items.count, 4)
+    }
+    
+    @MainActor
+    func testReadingItems() async throws {
+        try await asyncStore.insert(BoutiqueItem.allItems)
+        
+        XCTAssertEqual(asyncStore.items[0], BoutiqueItem.coat)
+        XCTAssertEqual(asyncStore.items[1], BoutiqueItem.sweater)
+        XCTAssertEqual(asyncStore.items[2], BoutiqueItem.purse)
+        XCTAssertEqual(asyncStore.items[3], BoutiqueItem.belt)
+        
+        XCTAssertEqual(asyncStore.items.count, 4)
+    }
+    
+    @MainActor
+    func testReadingPersistedItems() async throws {
+        try await asyncStore.insert(BoutiqueItem.allItems)
+        
+        // The new store has to fetch items from disk.
+        let newStore = try await Store<BoutiqueItem>(
+            storage: SQLiteStorageEngine.default(appendingPath: "Tests"),
+            cacheIdentifier: \.merchantID)
+        
+        XCTAssertEqual(newStore.items[0], BoutiqueItem.coat)
+        XCTAssertEqual(newStore.items[1], BoutiqueItem.sweater)
+        XCTAssertEqual(newStore.items[2], BoutiqueItem.purse)
+        XCTAssertEqual(newStore.items[3], BoutiqueItem.belt)
+        
+        XCTAssertEqual(newStore.items.count, 4)
+    }
+    
+    @MainActor
+    func testRemovingItems() async throws {
+        try await asyncStore.insert(BoutiqueItem.allItems)
+        try await asyncStore.remove(BoutiqueItem.coat)
+        
+        XCTAssertFalse(asyncStore.items.contains(BoutiqueItem.coat))
+        
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.sweater))
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.purse))
+        
+        try await asyncStore.remove([BoutiqueItem.sweater, BoutiqueItem.purse])
+        XCTAssertFalse(asyncStore.items.contains(BoutiqueItem.sweater))
+        XCTAssertFalse(asyncStore.items.contains(BoutiqueItem.purse))
+    }
+    
+    @MainActor
+    func testRemoveAll() async throws {
+        try await asyncStore.insert(BoutiqueItem.coat)
+        XCTAssertEqual(asyncStore.items.count, 1)
+        try await asyncStore.removeAll()
+        
+        try await asyncStore.insert(BoutiqueItem.uniqueItems)
+        XCTAssertEqual(asyncStore.items.count, 4)
+        try await asyncStore.removeAll()
+        XCTAssertTrue(asyncStore.items.isEmpty)
+    }
+    
+    @MainActor
+    func testChainingInsertOperations() async throws {
+        try await asyncStore.insert(BoutiqueItem.uniqueItems)
+        
+        try await asyncStore
+            .remove(BoutiqueItem.coat)
+            .insert(BoutiqueItem.belt)
+            .insert(BoutiqueItem.belt)
+            .run()
+        
+        XCTAssertEqual(asyncStore.items.count, 3)
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.sweater))
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.purse))
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.belt))
+        XCTAssertFalse(asyncStore.items.contains(BoutiqueItem.coat))
+        
+        try await asyncStore.removeAll()
+        
+        try await asyncStore
+            .insert(BoutiqueItem.belt)
+            .insert(BoutiqueItem.coat)
+            .remove([BoutiqueItem.belt])
+            .insert(BoutiqueItem.sweater)
+            .run()
+        
+        XCTAssertEqual(asyncStore.items.count, 2)
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.coat))
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.sweater))
+        XCTAssertFalse(asyncStore.items.contains(BoutiqueItem.belt))
+        
+        try await asyncStore
+            .insert(BoutiqueItem.belt)
+            .insert(BoutiqueItem.coat)
+            .insert(BoutiqueItem.purse)
+            .remove([BoutiqueItem.belt, .coat])
+            .insert(BoutiqueItem.sweater)
+            .run()
+        
+        XCTAssertEqual(asyncStore.items.count, 2)
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.sweater))
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.purse))
+        XCTAssertFalse(asyncStore.items.contains(BoutiqueItem.coat))
+        XCTAssertFalse(asyncStore.items.contains(BoutiqueItem.belt))
+        
+        try await asyncStore.removeAll()
+        
+        try await asyncStore
+            .insert(BoutiqueItem.coat)
+            .insert([BoutiqueItem.purse, BoutiqueItem.belt])
+            .run()
+        
+        XCTAssertEqual(asyncStore.items.count, 3)
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.purse))
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.belt))
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.coat))
+    }
+    
+    @MainActor
+    func testChainingRemoveOperations() async throws {
+        try await asyncStore
+            .insert(BoutiqueItem.uniqueItems)
+            .remove(BoutiqueItem.belt)
+            .remove(BoutiqueItem.purse)
+            .run()
+        
+        XCTAssertEqual(asyncStore.items.count, 2)
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.sweater))
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.coat))
+        
+        try await asyncStore.insert(BoutiqueItem.uniqueItems)
+        XCTAssertEqual(asyncStore.items.count, 4)
+        
+        try await asyncStore
+            .remove([BoutiqueItem.sweater, BoutiqueItem.coat])
+            .remove(BoutiqueItem.belt)
+            .run()
+        
+        XCTAssertEqual(asyncStore.items.count, 1)
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.purse))
+        
+        try await asyncStore
+            .removeAll()
+            .insert(BoutiqueItem.belt)
+            .run()
+        
+        XCTAssertEqual(asyncStore.items.count, 1)
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.belt))
+        
+        try await asyncStore
+            .removeAll()
+            .remove(BoutiqueItem.belt)
+            .insert(BoutiqueItem.belt)
+            .run()
+        
+        XCTAssertEqual(asyncStore.items.count, 1)
+        XCTAssertTrue(asyncStore.items.contains(BoutiqueItem.belt))
+    }
+    
+    @MainActor
+    func testChainingOperationsDontExecuteUnlessRun() async throws {
+        let operation = try await asyncStore
+            .insert(BoutiqueItem.coat)
+            .insert([BoutiqueItem.purse, BoutiqueItem.belt])
+        
+        XCTAssertEqual(asyncStore.items.count, 0)
+        XCTAssertFalse(asyncStore.items.contains(BoutiqueItem.purse))
+        XCTAssertFalse(asyncStore.items.contains(BoutiqueItem.belt))
+        XCTAssertFalse(asyncStore.items.contains(BoutiqueItem.coat))
+        
+        // Adding this line to get rid of the error about
+        // `operation` being unused, given that's the point of the test.
+        _ = operation
+    }
+    
+    @MainActor
+    func testPublishedItemsSubscription() async throws {
+        let uniqueItems = BoutiqueItem.uniqueItems
+        let expectation = XCTestExpectation(description: "uniqueItems is published and read")
+        
+        asyncStore.$items
+            .dropFirst()
+            .sink(receiveValue: { items in
+                XCTAssertEqual(items, uniqueItems)
+                expectation.fulfill()
+            })
+            .store(in: &cancellables)
+        
+        XCTAssertTrue(asyncStore.items.isEmpty)
+        
+        // Sets items under the hood
+        try await asyncStore.insert(uniqueItems)
+        wait(for: [expectation], timeout: 1)
+    }
+    
+}

--- a/Tests/BoutiqueTests/BoutiqueItem.swift
+++ b/Tests/BoutiqueTests/BoutiqueItem.swift
@@ -1,13 +1,15 @@
 import Foundation
 
 struct BoutiqueItem: Codable, Equatable, Identifiable {
-    var id: String { merchantID }
+    var id: String {
+        self.merchantID
+    }
+
     let merchantID: String
     let value: String
 }
 
 extension BoutiqueItem {
-
     static let coat = BoutiqueItem(
         merchantID: "1",
         value: "Coat"
@@ -47,5 +49,4 @@ extension BoutiqueItem {
         BoutiqueItem.purse,
         BoutiqueItem.belt,
     ]
-
 }

--- a/Tests/BoutiqueTests/BoutiqueItem.swift
+++ b/Tests/BoutiqueTests/BoutiqueItem.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-struct BoutiqueItem: Codable, Equatable {
+struct BoutiqueItem: Codable, Equatable, Identifiable {
+    var id: String { merchantID }
     let merchantID: String
     let value: String
 }

--- a/Tests/BoutiqueTests/StoreTests.swift
+++ b/Tests/BoutiqueTests/StoreTests.swift
@@ -8,11 +8,21 @@ final class StoreTests: XCTestCase {
     private var cancellables: Set<AnyCancellable> = []
 
     override func setUp() async throws {
-        store = try await Store<BoutiqueItem>(
-            storage: SQLiteStorageEngine.default(appendingPath: "Tests"),
-            cacheIdentifier: \.merchantID)
-
+        // Returns a `Store` using the non-async init. This is a workaround for Swift prioritizing the
+        // `async` version of the overload while in an `async` context, such as the `setUp()` here.
+        // There's a separate `AsyncStoreTests` file with matching tests using the async init.
+        func makeNonAsyncStore() -> Store<BoutiqueItem> {
+            Store<BoutiqueItem>(
+                storage: SQLiteStorageEngine.default(appendingPath: "Tests"),
+                cacheIdentifier: \.merchantID)
+        }
+        
+        store = makeNonAsyncStore()
         try await store.removeAll()
+    }
+    
+    override func tearDown() {
+        cancellables.removeAll()
     }
 
     @MainActor

--- a/Tests/BoutiqueTests/StoreTests.swift
+++ b/Tests/BoutiqueTests/StoreTests.swift
@@ -53,6 +53,23 @@ final class StoreTests: XCTestCase {
     }
 
     @MainActor
+    func testReadingPersistedItems() async throws {
+        try await store.insert(BoutiqueItem.allItems)
+        
+        // The new store has to fetch items from disk.
+        let newStore = try await Store<BoutiqueItem>(
+            storage: SQLiteStorageEngine.default(appendingPath: "Tests"),
+            cacheIdentifier: \.merchantID)
+        
+        XCTAssertEqual(newStore.items[0], BoutiqueItem.coat)
+        XCTAssertEqual(newStore.items[1], BoutiqueItem.sweater)
+        XCTAssertEqual(newStore.items[2], BoutiqueItem.purse)
+        XCTAssertEqual(newStore.items[3], BoutiqueItem.belt)
+
+        XCTAssertEqual(newStore.items.count, 4)
+    }
+
+    @MainActor
     func testRemovingItems() async throws {
         try await store.insert(BoutiqueItem.allItems)
         try await store.remove(BoutiqueItem.coat)

--- a/Tests/BoutiqueTests/StoreTests.swift
+++ b/Tests/BoutiqueTests/StoreTests.swift
@@ -8,7 +8,7 @@ final class StoreTests: XCTestCase {
     private var cancellables: Set<AnyCancellable> = []
 
     override func setUp() async throws {
-        store = Store<BoutiqueItem>(
+        store = try await Store<BoutiqueItem>(
             storage: SQLiteStorageEngine.default(appendingPath: "Tests"),
             cacheIdentifier: \.merchantID)
 

--- a/Tests/BoutiqueTests/StoredTests.swift
+++ b/Tests/BoutiqueTests/StoredTests.swift
@@ -227,7 +227,6 @@ final class StoredTests: XCTestCase {
         $items.$items
             .dropFirst()
             .sink(receiveValue: { items in
-                print("🔴", items)
                 XCTAssertEqual(items, uniqueItems)
                 expectation.fulfill()
             })

--- a/Tests/BoutiqueTests/StoredTests.swift
+++ b/Tests/BoutiqueTests/StoredTests.swift
@@ -1,0 +1,242 @@
+@testable import Boutique
+import Combine
+import XCTest
+
+extension Store where Item == BoutiqueItem {
+  static let boutiqueItemStore = Store<BoutiqueItem>(
+    storage: SQLiteStorageEngine.default(appendingPath: "StoredTests")
+  )
+}
+
+final class StoredTests: XCTestCase {
+    
+    @Stored(in: .boutiqueItemStore) private var items
+    
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func setUp() async throws {
+        try await $items.itemsHaveLoaded()
+        try await $items.removeAll()
+    }
+  
+  override func tearDown() {
+    cancellables.removeAll()
+  }
+
+
+    @MainActor
+    func testInsertingItem() async throws {
+        try await $items.insert(BoutiqueItem.coat)
+        XCTAssertTrue(items.contains(BoutiqueItem.coat))
+
+        try await $items.insert(BoutiqueItem.belt)
+        XCTAssertTrue(items.contains(BoutiqueItem.belt))
+        XCTAssertEqual(items.count, 2)
+    }
+
+    @MainActor
+    func testInsertingItems() async throws {
+        try await $items.insert([BoutiqueItem.coat, BoutiqueItem.sweater, BoutiqueItem.sweater, BoutiqueItem.purse])
+        XCTAssertTrue(items.contains(BoutiqueItem.coat))
+        XCTAssertTrue(items.contains(BoutiqueItem.sweater))
+        XCTAssertTrue(items.contains(BoutiqueItem.purse))
+    }
+
+    @MainActor
+    func testInsertingDuplicateItems() async throws {
+        XCTAssertTrue(items.isEmpty)
+        try await $items.insert(BoutiqueItem.allItems)
+        XCTAssertEqual(items.count, 4)
+    }
+
+    @MainActor
+    func testReadingItems() async throws {
+        try await $items.insert(BoutiqueItem.allItems)
+        
+        XCTAssertEqual(items[0], BoutiqueItem.coat)
+        XCTAssertEqual(items[1], BoutiqueItem.sweater)
+        XCTAssertEqual(items[2], BoutiqueItem.purse)
+        XCTAssertEqual(items[3], BoutiqueItem.belt)
+
+        XCTAssertEqual(items.count, 4)
+    }
+
+    @MainActor
+    func testReadingPersistedItems() async throws {
+        try await $items.insert(BoutiqueItem.allItems)
+
+        // The new store has to fetch items from disk.
+        let newStore = try await Store<BoutiqueItem>(
+            storage: SQLiteStorageEngine.default(appendingPath: "StoredTests"),
+            cacheIdentifier: \.merchantID)
+
+        XCTAssertEqual(newStore.items.count, 4)
+
+        XCTAssertEqual(newStore.items[0], BoutiqueItem.coat)
+        XCTAssertEqual(newStore.items[1], BoutiqueItem.sweater)
+        XCTAssertEqual(newStore.items[2], BoutiqueItem.purse)
+        XCTAssertEqual(newStore.items[3], BoutiqueItem.belt)
+    }
+
+    @MainActor
+    func testRemovingItems() async throws {
+        try await $items.insert(BoutiqueItem.allItems)
+        try await $items.remove(BoutiqueItem.coat)
+
+        XCTAssertFalse(items.contains(BoutiqueItem.coat))
+
+        XCTAssertTrue(items.contains(BoutiqueItem.sweater))
+        XCTAssertTrue(items.contains(BoutiqueItem.purse))
+
+        try await $items.remove([BoutiqueItem.sweater, BoutiqueItem.purse])
+        XCTAssertFalse(items.contains(BoutiqueItem.sweater))
+        XCTAssertFalse(items.contains(BoutiqueItem.purse))
+    }
+
+    @MainActor
+    func testRemoveAll() async throws {
+        try await $items.insert(BoutiqueItem.coat)
+        XCTAssertEqual(items.count, 1)
+        try await $items.removeAll()
+
+        try await $items.insert(BoutiqueItem.uniqueItems)
+        XCTAssertEqual(items.count, 4)
+        try await $items.removeAll()
+        XCTAssertTrue(items.isEmpty)
+    }
+
+    @MainActor
+    func testChainingInsertOperations() async throws {
+        try await $items.insert(BoutiqueItem.uniqueItems)
+
+        try await $items
+            .remove(BoutiqueItem.coat)
+            .insert(BoutiqueItem.belt)
+            .insert(BoutiqueItem.belt)
+            .run()
+
+        XCTAssertEqual(items.count, 3)
+        XCTAssertTrue(items.contains(BoutiqueItem.sweater))
+        XCTAssertTrue(items.contains(BoutiqueItem.purse))
+        XCTAssertTrue(items.contains(BoutiqueItem.belt))
+        XCTAssertFalse(items.contains(BoutiqueItem.coat))
+
+        try await $items.removeAll()
+
+        try await $items
+            .insert(BoutiqueItem.belt)
+            .insert(BoutiqueItem.coat)
+            .remove([BoutiqueItem.belt])
+            .insert(BoutiqueItem.sweater)
+            .run()
+
+        XCTAssertEqual(items.count, 2)
+        XCTAssertTrue(items.contains(BoutiqueItem.coat))
+        XCTAssertTrue(items.contains(BoutiqueItem.sweater))
+        XCTAssertFalse(items.contains(BoutiqueItem.belt))
+
+        try await $items
+            .insert(BoutiqueItem.belt)
+            .insert(BoutiqueItem.coat)
+            .insert(BoutiqueItem.purse)
+            .remove([BoutiqueItem.belt, .coat])
+            .insert(BoutiqueItem.sweater)
+            .run()
+
+        XCTAssertEqual(items.count, 2)
+        XCTAssertTrue(items.contains(BoutiqueItem.sweater))
+        XCTAssertTrue(items.contains(BoutiqueItem.purse))
+        XCTAssertFalse(items.contains(BoutiqueItem.coat))
+        XCTAssertFalse(items.contains(BoutiqueItem.belt))
+
+        try await $items.removeAll()
+
+        try await $items
+            .insert(BoutiqueItem.coat)
+            .insert([BoutiqueItem.purse, BoutiqueItem.belt])
+            .run()
+
+        XCTAssertEqual(items.count, 3)
+        XCTAssertTrue(items.contains(BoutiqueItem.purse))
+        XCTAssertTrue(items.contains(BoutiqueItem.belt))
+        XCTAssertTrue(items.contains(BoutiqueItem.coat))
+    }
+
+    @MainActor
+    func testChainingRemoveOperations() async throws {
+        try await $items
+            .insert(BoutiqueItem.uniqueItems)
+            .remove(BoutiqueItem.belt)
+            .remove(BoutiqueItem.purse)
+            .run()
+
+        XCTAssertEqual(items.count, 2)
+        XCTAssertTrue(items.contains(BoutiqueItem.sweater))
+        XCTAssertTrue(items.contains(BoutiqueItem.coat))
+
+        try await $items.insert(BoutiqueItem.uniqueItems)
+        XCTAssertEqual(items.count, 4)
+
+        try await $items
+            .remove([BoutiqueItem.sweater, BoutiqueItem.coat])
+            .remove(BoutiqueItem.belt)
+            .run()
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertTrue(items.contains(BoutiqueItem.purse))
+
+        try await $items
+            .removeAll()
+            .insert(BoutiqueItem.belt)
+            .run()
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertTrue(items.contains(BoutiqueItem.belt))
+
+        try await $items
+            .removeAll()
+            .remove(BoutiqueItem.belt)
+            .insert(BoutiqueItem.belt)
+            .run()
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertTrue(items.contains(BoutiqueItem.belt))
+    }
+
+    @MainActor
+    func testChainingOperationsDontExecuteUnlessRun() async throws {
+        let operation = try await $items
+            .insert(BoutiqueItem.coat)
+            .insert([BoutiqueItem.purse, BoutiqueItem.belt])
+
+        XCTAssertEqual(items.count, 0)
+        XCTAssertFalse(items.contains(BoutiqueItem.purse))
+        XCTAssertFalse(items.contains(BoutiqueItem.belt))
+        XCTAssertFalse(items.contains(BoutiqueItem.coat))
+
+        // Adding this line to get rid of the error about
+        // `operation` being unused, given that's the point of the test.
+        _ = operation
+    }
+
+    @MainActor
+    func testPublishedItemsSubscription() async throws {
+        let uniqueItems = BoutiqueItem.uniqueItems
+        let expectation = XCTestExpectation(description: "uniqueItems is published and read")
+
+        $items.$items
+            .dropFirst()
+            .sink(receiveValue: { items in
+                print("🔴", items)
+                XCTAssertEqual(items, uniqueItems)
+                expectation.fulfill()
+            })
+            .store(in: &cancellables)
+
+        XCTAssertTrue(items.isEmpty)
+
+        // Sets items under the hood
+        try await $items.insert(uniqueItems)
+        wait(for: [expectation], timeout: 1)
+    }
+}

--- a/Tests/BoutiqueTests/StoredTests.swift
+++ b/Tests/BoutiqueTests/StoredTests.swift
@@ -3,26 +3,25 @@ import Combine
 import XCTest
 
 extension Store where Item == BoutiqueItem {
-  static let boutiqueItemStore = Store<BoutiqueItem>(
-    storage: SQLiteStorageEngine.default(appendingPath: "StoredTests")
-  )
+    static let boutiqueItemsStore = Store<BoutiqueItem>(
+        storage: SQLiteStorageEngine.default(appendingPath: "StoredTests")
+    )
 }
 
 final class StoredTests: XCTestCase {
-    
-    @Stored(in: .boutiqueItemStore) private var items
-    
+
+    @Stored(in: .boutiqueItemsStore) private var items
+
     private var cancellables: Set<AnyCancellable> = []
 
     override func setUp() async throws {
         try await $items.itemsHaveLoaded()
         try await $items.removeAll()
     }
-  
-  override func tearDown() {
-    cancellables.removeAll()
-  }
 
+    override func tearDown() {
+        cancellables.removeAll()
+    }
 
     @MainActor
     func testInsertingItem() async throws {
@@ -52,7 +51,7 @@ final class StoredTests: XCTestCase {
     @MainActor
     func testReadingItems() async throws {
         try await $items.insert(BoutiqueItem.allItems)
-        
+
         XCTAssertEqual(items[0], BoutiqueItem.coat)
         XCTAssertEqual(items[1], BoutiqueItem.sweater)
         XCTAssertEqual(items[2], BoutiqueItem.purse)
@@ -68,7 +67,8 @@ final class StoredTests: XCTestCase {
         // The new store has to fetch items from disk.
         let newStore = try await Store<BoutiqueItem>(
             storage: SQLiteStorageEngine.default(appendingPath: "StoredTests"),
-            cacheIdentifier: \.merchantID)
+            cacheIdentifier: \.merchantID
+        )
 
         XCTAssertEqual(newStore.items.count, 4)
 
@@ -239,3 +239,4 @@ final class StoredTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 }
+

--- a/Tests/BoutiqueTests/StoredValueTests.swift
+++ b/Tests/BoutiqueTests/StoredValueTests.swift
@@ -115,3 +115,4 @@ final class StoredValueTests: XCTestCase {
     }
 
 }
+


### PR DESCRIPTION
This change adds 2 ways to observe/await for `items` to be loaded in the Store: 
- via the new `async` `Store.init` overload
- by using `await store.itemsHaveLoaded()` before accessing `store.items`

## Why
I ran into an issue after implementing a thin `Store` dependency wrapper to use with [The Composable Architecture](https://github.com/pointfreeco/swift-composable-architecture), where I tried loading `store.items` on launch, but it often returned an empty array. 

I believe part of the issue is that TCA seems to load `@Dependeny` lazily, so accessing the `items` right after init doesn't work. One workaround I found is to add `_ = someStore` to the root reducer's `init`. That worked better, however I worry that there might still be a race if/when the stored data grows and takes longer to load. 

## Compatibility

If the store was constructed in an `async` context, the compiler will try to use the new `async` version of the `init` and return errors about missing `try` and `await`. This could be addressed with different naming, but I'm not sure what could be used here. Thoughts? 🤔 