### PR TITLE
Fix for unexpected removeItems chaining behavior

### DIFF
--- a/Sources/Boutique/Store.ItemRemovalStrategy.swift
+++ b/Sources/Boutique/Store.ItemRemovalStrategy.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public extension Store {
+extension Store {
     /// An invalidation strategy for a `Store` instance.
     ///
     /// An `ItemRemovalStrategy` provides control over how items are removed from the `Store`

--- a/Sources/Boutique/Store.swift
+++ b/Sources/Boutique/Store.swift
@@ -385,14 +385,14 @@ public extension Store {
 // Internal versions of the `insert`, `remove`, and `removeAll` function code paths so we can avoid duplicating code.
 internal extension Store {
     func performInsert(_ item: Item, firstRemovingExistingItems existingItemsStrategy: ItemRemovalStrategy<Item>? = nil) async throws {
-        var currentItems = await self.items
-
         if let strategy = existingItemsStrategy {
             // Remove items from disk and memory based on the cache invalidation strategy
-            try await self.removeItems(withStrategy: strategy, items: &currentItems)
+            var removedItems: [Item] = [item]
+            try await self.removeItems(&removedItems, withStrategy: strategy)
         }
 
         // Take the current items array and turn it into an OrderedDictionary.
+        let currentItems = await self.items
         let identifier = item[keyPath: self.cacheIdentifier]
         let currentItemsKeys = currentItems.map({ $0[keyPath: self.cacheIdentifier] })
         var currentValuesDictionary = OrderedDictionary<String, Item>(uniqueKeys: currentItemsKeys, values: currentItems)
@@ -407,11 +407,11 @@ internal extension Store {
     }
 
     func performInsert(_ items: [Item], firstRemovingExistingItems existingItemsStrategy: ItemRemovalStrategy<Item>? = nil) async throws {
-        var currentItems = await self.items
 
         if let strategy = existingItemsStrategy {
             // Remove items from disk and memory based on the cache invalidation strategy
-            try await self.removeItems(withStrategy: strategy, items: &currentItems)
+            var removedItems = items
+            try await self.removeItems(&removedItems, withStrategy: strategy)
         }
 
         var insertedItemsDictionary = OrderedDictionary<String, Item>()
@@ -424,6 +424,7 @@ internal extension Store {
         }
 
         // Take the current items array and turn it into an OrderedDictionary.
+        let currentItems = await self.items
         let currentItemsKeys = currentItems.map({ $0[keyPath: self.cacheIdentifier] })
         var currentValuesDictionary = OrderedDictionary<String, Item>(uniqueKeys: currentItemsKeys, values: currentItems)
 
@@ -502,7 +503,7 @@ private extension Store {
         try await self.storageEngine.remove(keys: itemKeys)
     }
 
-    func removeItems(withStrategy strategy: ItemRemovalStrategy<Item>, items: inout [Item]) async throws {
+    func removeItems(_ items: inout [Item], withStrategy strategy: ItemRemovalStrategy<Item>) async throws {
         let itemsToRemove = strategy.removedItems(items)
 
         // If we're using the `.removeNone` strategy then there are no items to invalidate and we can return early

--- a/Sources/Boutique/Store.swift
+++ b/Sources/Boutique/Store.swift
@@ -509,24 +509,17 @@ private extension Store {
         // If we're using the `.removeNone` strategy then there are no items to invalidate and we can return early
         guard itemsToRemove.count != 0 else { return }
 
-        // If we're using the `.removeAll` strategy then we want to remove all the data without iterating
-        // Else, we're using a strategy and need to iterate over all of the `itemsToInvalidate` and invalidate them
-        if items.count == itemsToRemove.count {
-            items = []
-            try await self.storageEngine.removeAllData()
-        } else {
-            items = items.filter { item in
-                !itemsToRemove.contains(where: {
-                    $0[keyPath: cacheIdentifier] == item[keyPath: cacheIdentifier]
-                }
-            )}
-            let itemKeys = items.map({ CacheKey(verbatim: $0[keyPath: self.cacheIdentifier]) })
-
-            if itemKeys.count == 1 {
-                try await self.storageEngine.remove(key: itemKeys[0])
-            } else {
-                try await self.storageEngine.remove(keys: itemKeys)
+        items = items.filter { item in
+            !itemsToRemove.contains(where: {
+                $0[keyPath: cacheIdentifier] == item[keyPath: cacheIdentifier]
             }
+        )}
+        let itemKeys = items.map({ CacheKey(verbatim: $0[keyPath: self.cacheIdentifier]) })
+
+        if itemKeys.count == 1 {
+            try await self.storageEngine.remove(key: itemKeys[0])
+        } else {
+            try await self.storageEngine.remove(keys: itemKeys)
         }
     }
 }

--- a/Sources/Boutique/Store.swift
+++ b/Sources/Boutique/Store.swift
@@ -514,7 +514,8 @@ private extension Store {
                 $0[keyPath: cacheIdentifier] == item[keyPath: cacheIdentifier]
             }
         )}
-        let itemKeys = items.map({ CacheKey(verbatim: $0[keyPath: self.cacheIdentifier]) })
+
+        let itemKeys = itemsToRemove.map({ CacheKey(verbatim: $0[keyPath: self.cacheIdentifier]) })
 
         if itemKeys.count == 1 {
             try await self.storageEngine.remove(key: itemKeys[0])


### PR DESCRIPTION
Boutique was exhibiting incorrect behavior when chaining the `remove()` function with an `insert()` after, due to an underlying implementation bug. The code below demonstrates how the bug manifested.

```swift
// We start with self.items = [1, 2, 3, 4, 5, 6, 7, 8]

// An API call is made and we receive 1, 2, 3, 8, 9, and 10 to be inserted into to self.items. We pass that `updatedItems` array into an `update` function that removes any items that need to be removed, and then inserts the newly updated items.

func update(_ updatedItems: [Int]) async throws {
    let items = self.items.filter({ updatedItems.contains($0) })

    try await self.$items
        .remove(items)
        .insert(updatedItems)
        .run()
}

// `self.items` now should be [1, 2, 3, 4, 5, 6, 7, 8] 
// `self.items` is actually [10] 
```

Unfortunately I made an assumption that when the size of the items being removed and inserted was the same, Boutique would use `ItemRemovalStrategy.removeAll` rather than `ItemRemovalStrategy.removeItems(items)`. In practice this made sense in a very early version of Boutique, but does not any more and can lead to unexpected errors. The result is that every time a remove was chained to an insert, `removeAll` would be called, leaving a Store with just it's last element.