### PR TITLE
Add test to verify StoredValue persistence across instances

### DIFF
--- a/Tests/BoutiqueTests/StoredValueTests.swift
+++ b/Tests/BoutiqueTests/StoredValueTests.swift
@@ -159,5 +159,24 @@ final class StoredValueTests: XCTestCase {
 
         await fulfillment(of: [expectation], timeout: 1)
     }
+
+    func testStoredValuePersistsAcrossInstances() async throws {
+        // First instance - set a value
+        await self.$storedItem.set(.sweater)
+        XCTAssertEqual(self.storedItem, .sweater)
+        
+        // Create a new instance with the same key
+        @StoredValue<BoutiqueItem>(key: "storedItem")
+        var newInstance = .coat  // Default value should be ignored since we have a stored value
+        
+        // Verify the new instance has the persisted value
+        XCTAssertEqual(newInstance, .sweater)
+        
+        // Change value in new instance
+        await $newInstance.set(.belt)
+        
+        // Verify original instance sees the change
+        XCTAssertEqual(self.storedItem, .belt)
+    }
 }
 


### PR DESCRIPTION
I added a new test that verifies @StoredValue properly persists data across multiple instances.

The test verifies that:
1. When a value is stored using one instance, it can be retrieved using another instance with the same key
2. Changes made in the new instance are reflected in the original instance
3. The persistence works correctly across different instances of StoredValue

This helps ensure the persistence behaviour of @StoredValue works as expected when the same key is used in different places.