### PR TITLE
Fixes Views not updating when a StoredValue or SecurelyStoredValue updates

### DIFF
--- a/Demo/Demo/Components/FavoritesCarouselView.swift
+++ b/Demo/Demo/Components/FavoritesCarouselView.swift
@@ -126,7 +126,7 @@ private extension FavoritesCarouselView {
             })
 
             Button(action: {
-                self.appState.funkyRedPandaModeEnabled.toggle()
+                self.appState.$funkyRedPandaModeEnabled.toggle()
             }, label: {
                 Image(systemName: "sun.max.circle.fill")
                     .opacity(self.images.isEmpty ? 0.0 : 1.0)

--- a/Sources/Boutique/SecurelyStoredValue.swift
+++ b/Sources/Boutique/SecurelyStoredValue.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import SwiftUI
 
 /// The @``SecurelyStoredValue`` property wrapper automagically persists a single `Item` in the system `Keychain`
 /// rather than an array of items that would be persisted in a ``Store`` or using @``Stored``.
@@ -50,7 +51,7 @@ import Observation
 @MainActor
 @Observable
 @propertyWrapper
-public final class SecurelyStoredValue<Item: StorableItem> {
+public final class SecurelyStoredValue<Item: StorableItem>: DynamicProperty {
     private let observationRegistrar = ObservationRegistrar()
     private let valueSubject = AsyncValueSubject<Item?>(nil)
 

--- a/Sources/Boutique/StoredValue.swift
+++ b/Sources/Boutique/StoredValue.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import SwiftUI
 
 /// The @``StoredValue`` property wrapper to automagically persist a single `Item` in `UserDefaults`
 /// rather than an array of items that would be persisted in a ``Store`` or using @``Stored``.
@@ -55,7 +56,7 @@ import Observation
 @MainActor
 @Observable
 @propertyWrapper
-public final class StoredValue<Item: StorableItem> {
+public final class StoredValue<Item: StorableItem>: DynamicProperty {
     private let observationRegistrar = ObservationRegistrar()
     private let valueSubject: AsyncValueSubject<Item>
     private let cachedValue: CachedValue<Item>
@@ -95,7 +96,7 @@ public final class StoredValue<Item: StorableItem> {
 
     /// The currently stored value
     public var wrappedValue: Item {
-        self.cachedValue.wrappedValue
+		self.retrieveItem()
     }
 
     /// A ``StoredValue`` which exposes ``set(_:)`` and ``reset()`` functions alongside an `AsyncStream` of ``values``.


### PR DESCRIPTION
`StoredValue` and `SecurelyStoredValue` now conform to `DynamicProperty`, so Views know to re-render whenever their values change. This change was tested by me in Plinky and by @joeycarmello in #77, so I feel confident that this change is correct.